### PR TITLE
Allow threads while executing rust portion of the code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "pynexrad"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "chrono",
  "image 0.25.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pynexrad"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 resolver = "2"
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -14,8 +14,7 @@ use crate::pymodel::py_sweep::PySweep;
 use crate::util::create_date;
 
 /// Downloads and decodes a nexrad file
-#[pyfunction]
-fn download_nexrad_file(
+fn download_nexrad_file_impl(
     site: String,
     year: i32,
     month: u32,
@@ -45,8 +44,7 @@ fn download_nexrad_file(
 }
 
 /// Lists records from a particular site and date
-#[pyfunction]
-fn list_records(site: String, year: i32, month: u32, day: u32) -> Vec<String> {
+fn list_records_impl(site: String, year: i32, month: u32, day: u32) -> Vec<String> {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     let files = rt
@@ -61,7 +59,34 @@ fn list_records(site: String, year: i32, month: u32, day: u32) -> Vec<String> {
 /// A Python module implemented in Rust.
 #[pymodule]
 fn pynexrad(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(download_nexrad_file, m)?)?;
+    #[pyfn(m)]
+    fn download_nexrad_file(
+        py: Python,
+        site: String,
+        year: i32,
+        month: u32,
+        day: u32,
+        identifier: String,
+    ) -> PyResult<PyLevel2File> {
+        let result = py.allow_threads(move || download_nexrad_file_impl(site, year, month, day, identifier));
+    
+        Ok(result)
+    }
+
+    #[pyfn(m)]
+    fn list_records(
+        py: Python,
+        site: String, 
+        year: i32,
+        month: u32,
+        day: u32,
+    ) -> PyResult<Vec<String>> {
+        let result = py.allow_threads(move || list_records_impl(site, year, month, day));
+
+        Ok(result)
+    }
+    
+    // m.add_function(wrap_pyfunction!(download_nexrad_file, m)?)?;
     m.add_function(wrap_pyfunction!(list_records, m)?)?;
     m.add_class::<PyLevel2File>()?;
     m.add_class::<PyScan>()?;

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -68,15 +68,16 @@ fn pynexrad(_py: Python, m: &PyModule) -> PyResult<()> {
         day: u32,
         identifier: String,
     ) -> PyResult<PyLevel2File> {
-        let result = py.allow_threads(move || download_nexrad_file_impl(site, year, month, day, identifier));
-    
+        let result =
+            py.allow_threads(move || download_nexrad_file_impl(site, year, month, day, identifier));
+
         Ok(result)
     }
 
     #[pyfn(m)]
     fn list_records(
         py: Python,
-        site: String, 
+        site: String,
         year: i32,
         month: u32,
         day: u32,
@@ -85,7 +86,7 @@ fn pynexrad(_py: Python, m: &PyModule) -> PyResult<()> {
 
         Ok(result)
     }
-    
+
     // m.add_function(wrap_pyfunction!(download_nexrad_file, m)?)?;
     m.add_function(wrap_pyfunction!(list_records, m)?)?;
     m.add_class::<PyLevel2File>()?;


### PR DESCRIPTION
This allows the calling python program to use multithreading instead of multiprocessing.