### PR TITLE
Consume nexrad updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "nexrad-decode",
  "pyo3",
  "tokio",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 pyo3 = "0.19.0"
 chrono = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+uom = { version = "0.36.0"}
 nexrad-data = { version = "0.1.0-rc1" }
 nexrad-decode = { version = "0.1.0-rc1" }
 

--- a/src/model/sweep.rs
+++ b/src/model/sweep.rs
@@ -1,8 +1,16 @@
 use chrono::{DateTime, Utc};
-use nexrad_decode::messages::{digital_radar_data::{Message, ScaledMomentValue}, volume_coverage_pattern::ElevationDataBlock};
+use nexrad_decode::messages::{
+    digital_radar_data::{Message, ScaledMomentValue},
+    volume_coverage_pattern::ElevationDataBlock,
+};
 
 use crate::model::sweep_data::SweepData;
-use uom::si::{angle::{degree, radian}, f64::Angle, length::kilometer, velocity::meter_per_second};
+use uom::si::{
+    angle::{degree, radian},
+    f64::Angle,
+    length::kilometer,
+    velocity::meter_per_second,
+};
 
 pub struct Sweep {
     pub elevation: f32,
@@ -70,7 +78,13 @@ fn extract_nyquist_vel(radials: &Vec<Box<Message>>) -> f32 {
         .nyquist_velocity();
 
     for radial in radials {
-        if nyquist_vel != radial.radial_data_block.as_ref().unwrap().nyquist_velocity() {
+        if nyquist_vel
+            != radial
+                .radial_data_block
+                .as_ref()
+                .unwrap()
+                .nyquist_velocity()
+        {
             panic!("Nyquist values are not consistent");
         }
     }
@@ -100,8 +114,14 @@ fn extract_range_info(radial: &Message, data_type: &str) -> (f32, f32, i32) {
         sample_data_moment = radial.velocity_data_block.as_ref().unwrap();
     }
 
-    let range_step = sample_data_moment.header.data_moment_range_sample_interval().get::<kilometer>() as f32;
-    let range_first = sample_data_moment.header.data_moment_range().get::<kilometer>() as f32;
+    let range_step = sample_data_moment
+        .header
+        .data_moment_range_sample_interval()
+        .get::<kilometer>() as f32;
+    let range_first = sample_data_moment
+        .header
+        .data_moment_range()
+        .get::<kilometer>() as f32;
     let range_count = sample_data_moment.header.number_of_data_moment_gates as i32;
 
     return (range_first, range_step, range_count);
@@ -112,7 +132,10 @@ impl Sweep {
         let elevation = elevation_meta.elevation_angle().get::<radian>() as f32;
 
         let rad_hdr = &radials[0].header;
-        let az_first = rad_hdr.azimuth_indexing_mode().unwrap_or(Angle::new::<degree>(0.0)).get::<radian>() as f32;
+        let az_first = rad_hdr
+            .azimuth_indexing_mode()
+            .unwrap_or(Angle::new::<degree>(0.0))
+            .get::<radian>() as f32;
         let az_count = radials.len() as i32;
         let az_step = rad_hdr.azimuth_resolution_spacing().get::<radian>() as f32;
 

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -1,5 +1,5 @@
 use nexrad_data::volume::File;
-use nexrad_decode::messages::{digital_radar_data, Message};
+use nexrad_decode::messages::{digital_radar_data, volume_coverage_pattern, Message};
 
 use crate::model::sweep::Sweep;
 
@@ -10,7 +10,7 @@ pub struct Volume {
 impl Volume {
     pub(crate) fn new(file: &File) -> Self {
         let mut radials: Vec<Box<digital_radar_data::Message>> = Vec::new();
-        let mut max_el_number: u8 = 0;
+        let mut vcp: Option<Box<volume_coverage_pattern::Message>> = None;
 
         for mut record in file.records() {
             if record.compressed() {
@@ -21,17 +21,20 @@ impl Volume {
 
             let messages = record.messages().expect("Has messages");
             for message in messages {
-                if let Message::DigitalRadarData(radar_data_message) = message.message {
-                    if radar_data_message.header.elevation_number > max_el_number {
-                        max_el_number = radar_data_message.header.elevation_number;
+                match message.message {
+                    Message::DigitalRadarData(radar_data_message) => {
+                        radials.push(radar_data_message);
+                    },
+                    Message::VolumeCoveragePattern(volume_coverage_pattern) => {
+                        vcp = Some(volume_coverage_pattern);
                     }
-                    radials.push(radar_data_message);
+                    _ => {}
                 }
             }
         }
 
         let mut sweeps: Vec<Vec<Box<digital_radar_data::Message>>> = Vec::new();
-        for _ in 0..max_el_number {
+        for _ in 0..vcp.as_ref().unwrap().header.number_of_elevation_cuts {
             sweeps.push(Vec::new());
         }
 
@@ -40,8 +43,8 @@ impl Volume {
         }
 
         let mut result_sweeps: Vec<Sweep> = Vec::new();
-        for sweep in sweeps {
-            result_sweeps.push(Sweep::new(&sweep));
+        for (i, sweep) in sweeps.iter().enumerate() {
+            result_sweeps.push(Sweep::new(&vcp.as_ref().unwrap().elevations[i], &sweep));
         }
 
         Self {

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -24,7 +24,7 @@ impl Volume {
                 match message.message {
                     Message::DigitalRadarData(radar_data_message) => {
                         radials.push(radar_data_message);
-                    },
+                    }
                     Message::VolumeCoveragePattern(volume_coverage_pattern) => {
                         vcp = Some(volume_coverage_pattern);
                     }


### PR DESCRIPTION
Consume nexrad updates
- Use uom quantities for conversion instead of duplicating scaling logic in this package
- Use the vcp message for info about the number of sweeps and sweep metadata